### PR TITLE
unclosed url tokens at end of file are fine

### DIFF
--- a/lib/parse/tokenize.js
+++ b/lib/parse/tokenize.js
@@ -401,6 +401,10 @@ function consumeUrl(chars) {
             if (chars.consume(')')) {
                 return { end: chars.index + 1, start, types: ['<url-token>'], value }
             }
+            if (chars.atEnd()) {
+                error({ message: 'Unclosed url' })
+                return { end: chars.index + 1, start, types: ['<url-token>'], value }
+            }
             consumeBadUrl(chars)
             return { end: chars.index + 1, start, types: ['<bad-url-token>'], value: '' }
         }


### PR DESCRIPTION
https://drafts.csswg.org/css-syntax/#consume-url-token

> 4.3.6. Consume a url token

> whitespace
Consume as much whitespace as possible. If the next input code point is U+0029 RIGHT PARENTHESIS ()) or EOF, consume it and return the `<url-token>` (if EOF was encountered, this is a parse error); otherwise, consume the remnants of a bad url, create a <bad-url-token>`, and return it.

This is a valid `<url-token>` :

```css
url( a

```

