### PR TITLE
`<url-token>` start position must account for escape sequences

### DIFF
--- a/lib/parse/tokenize.js
+++ b/lib/parse/tokenize.js
@@ -278,7 +278,7 @@ function consumeIdentifierLike(chars) {
             if (isQuote(chars.next()) || (isWhitespace(chars.next()) && isQuote(chars.next(1, 1)))) {
                 return { end: chars.index + 1, start, types: ['<function-token>'], value: lowercase }
             }
-            return { ...consumeUrl(chars), start }
+            return consumeUrl(chars, identifier)
         }
         return { end: chars.index + 1, start, types: ['<function-token>'], value: lowercase }
     }
@@ -385,11 +385,12 @@ function consumeString(chars) {
 
 /**
  * @param {Stream} chars
+ * @param {object} identifier
  * @returns {object}
  * @see {@link https://drafts.csswg.org/css-syntax-3/#consume-url-token}
  */
-function consumeUrl(chars) {
-    const start = chars.index - 3
+function consumeUrl(chars, identifier) {
+    const start = identifier.start
     let value = ''
     chars.consumeRunOf(isWhitespace)
     for (const char of chars) {

--- a/lib/parse/tokenize.js
+++ b/lib/parse/tokenize.js
@@ -278,7 +278,7 @@ function consumeIdentifierLike(chars) {
             if (isQuote(chars.next()) || (isWhitespace(chars.next()) && isQuote(chars.next(1, 1)))) {
                 return { end: chars.index + 1, start, types: ['<function-token>'], value: lowercase }
             }
-            return consumeUrl(chars)
+            return { ...consumeUrl(chars), start }
         }
         return { end: chars.index + 1, start, types: ['<function-token>'], value: lowercase }
     }


### PR DESCRIPTION
Example:

```css
\\75 Rl(foo)

```

Before : `startIndex: 3`
After: ` startIndex: 0`