### PR TITLE
Fix typo in `end` for `<hash-token>`

### DIFF
--- a/lib/parse/tokenize.js
+++ b/lib/parse/tokenize.js
@@ -449,9 +449,9 @@ function consumeToken(chars) {
         if (isIdentifierCharacter(chars.next()) || startsWithEscaped(...chars.next(2))) {
             const types = ['<hash-token>']
             if (startsWithIdentifier(...chars.next(3))) {
-                return { ...consumeIdentifier(chars), end: char.index + 1, start, type: 'id', types }
+                return { ...consumeIdentifier(chars), end: chars.index + 1, start, type: 'id', types }
             }
-            return { ...consumeIdentifier(chars), end: char.index + 1, start, types }
+            return { ...consumeIdentifier(chars), end: chars.index + 1, start, types }
         }
     } else if (char === '+') {
         if (startsWithNumber(chars)) {


### PR DESCRIPTION
This was always `NaN` because `char` is the actual character, not the stream.