### PR TITLE
Remove `Generated from ...` comment

### DIFF
--- a/lib/descriptors/definitions.js
+++ b/lib/descriptors/definitions.js
@@ -1,6 +1,4 @@
 
-// Generated from /var/www/packages/css/scripts/initial.js
-
 const { list, omitted } = require('../values/value.js')
 
 module.exports = {

--- a/lib/properties/definitions.js
+++ b/lib/properties/definitions.js
@@ -1,6 +1,4 @@
 
-// Generated from /var/www/packages/css/scripts/initial.js
-
 const { list, omitted } = require('../values/value.js')
 
 module.exports = {

--- a/lib/values/definitions.js
+++ b/lib/values/definitions.js
@@ -1,6 +1,4 @@
 
-// Generated from /var/www/packages/css/scripts/extract.js
-
 module.exports = {
     '<abs()>': 'abs(<calc-sum>)',
     '<absolute-size>': 'xx-small | x-small | small | medium | large | x-large | xx-large',

--- a/scripts/extract.js
+++ b/scripts/extract.js
@@ -1001,7 +1001,7 @@ function addRules(definitions = [], key) {
  */
 function build(specifications) {
 
-    const header = `\n// Generated from ${__filename}\n\nmodule.exports = {\n`
+    const header = '\nmodule.exports = {\n'
 
     Object.entries(specifications).forEach(([key, { atrules, properties, selectors, values }]) => {
         if (excluded.specifications.includes(key)) {

--- a/scripts/initial.js
+++ b/scripts/initial.js
@@ -158,7 +158,7 @@ function serializeDescriptorDefinitions(descriptors) {
  */
 function serializeDefinitions() {
     const dependency = "const { list, omitted } = require('../values/value.js')"
-    const header = `\n// Generated from ${__filename}\n\n${dependency}\n\nmodule.exports = {\n`
+    const header = `\n${dependency}\n\nmodule.exports = {\n`
     return Promise.all([
         fs.writeFile(
             path.resolve(__dirname, '../lib/descriptors/definitions.js'),


### PR DESCRIPTION
Follow-up #7

It's overwritten to the local path of the contributer's one,
e.g. `// Generated from C:\Users\XXX\Documents\GitHub\css\scripts\initial.js`
